### PR TITLE
Bump Go version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.13
+FROM golang:1.16
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
Matches the Go version Terraform uses, at https://github.com/hashicorp/terraform/blob/main/.go-version

cc @jcudit 